### PR TITLE
Lexxie analysis

### DIFF
--- a/febrb.cxx
+++ b/febrb.cxx
@@ -258,6 +258,10 @@ void lpc_callback(midas::odb &o) {
     // Turn on or off?
     if(o){ //turn on
       
+      // Enable VCC LDO and DAC control                                                                     
+      SendBrbCommand("enable_ldo_en\r\n");
+      SendBrbCommand("enable_vccl_en\r\n");
+      SendBrbCommand("enable_mezzanine_dac\r\n");
 
       int led_mask = 0;
       std::string led_string;

--- a/hv_control/set_hv_auto.py
+++ b/hv_control/set_hv_auto.py
@@ -1,6 +1,7 @@
 import subprocess
 import time
 import sys
+import json
 
 n = int(sys.argv[1])
 
@@ -16,7 +17,7 @@ for i in range(Start_Channel,Start_Channel+int(Num_CH)):
     Get_PMT_CIN = f'odbedit -c "ls /Analyzer/PMT_List[{i}]"'
     PMT_CIN_Output = subprocess.check_output(Get_PMT_CIN, shell=True)
     PMT_CIN_str = str(PMT_CIN_Output.strip())
-    
+
     #Make the string received readable
     if i>9:
         start_string = 48
@@ -40,8 +41,12 @@ for i in range(Start_Channel,Start_Channel+int(Num_CH)):
         Get_HV = f'curl "https://modulo.triumf.ca/api/get_pmt_value?cin={PMT_CIN}&value=EBB"'
         #Record the output
         Output_HV = subprocess.check_output(Get_HV, shell=True)
+
+        pmt_cin_data = json.loads(Output_HV)
+        hv_hama = pmt_cin_data["EBB"]
+        
         #Converts the output to an integer
-        HV_Value = int(Output_HV.strip()) + n
+        HV_Value = int(hv_hama) + n
         print("The HV value for the PMT on CH "+ str(i) + " is " + str(HV_Value))
     
         #Sets the HV value on the mpmt test site

--- a/hv_control/set_hv_mpmt.py
+++ b/hv_control/set_hv_mpmt.py
@@ -1,0 +1,60 @@
+import subprocess
+import time
+import sys
+import json
+
+n = int(sys.argv[1])
+
+Start_Channel=0
+Num_CH = 19
+HV_Change=0 #The change in the HV from the
+
+# Specify the path to the JSON file in another directory
+file_path = '/home/mpmttest/online/mpmt-mainboard-xilinx/hv_control/jsonFiles/data_Run_1265.json'
+
+# Open the file and load its contents as a JSON object
+with open(file_path, 'r') as file:
+    json_data = json.load(file)
+
+# Print the JSON data
+print(json.dumps(json_data, indent=2))  # Use indent for pretty-printing
+
+
+
+for i in range(Start_Channel,Start_Channel+int(Num_CH)):
+
+    print("Starting for CH " + str(i))
+
+    PMT_CIN= ""
+    Get_values = f'curl "https://modulo.triumf.ca/api/get_all_installed_pmt_values?mpmtin=mPMT-TRI-00072&value=EBB,TTS&ordered_by=channel_id,coord_id"'
+    #Record the output
+    Output_values = subprocess.check_output(Get_values, shell=True)
+
+    pmt_cin_data = json.loads(Output_values)
+    cin = pmt_cin_data["CIN"]
+
+    #Converts the output to an integer
+    PMT_CIN = cin[i]
+
+    Set_cin = f'odbedit -c "set /Analyzer/PMT_List[{i}] {PMT_CIN}"'
+#    subprocess.run(Set_cin, shell=True, check=True)
+
+    print("The CIN for the for the PMT on CH " + str(i) + " is " + PMT_CIN)
+
+    #Get the HV value for the given PMT
+    Get_HV = f'curl "https://modulo.triumf.ca/api/get_all_installed_pmt_values?mpmtin=mPMT-TRI-00072&value=EBB,TTS&ordered_by=channel_id,coord_id"'
+
+    #Record the output
+    Output_HV = subprocess.check_output(Get_HV, shell=True)
+
+    pmt_cin_data = json.loads(Output_HV)
+    hv_hama = pmt_cin_data["EBB"]
+        
+    #Converts the output to an integer
+    HV_Value = int(hv_hama[i]) + n
+
+    print("The HV value for the PMT on CH "+ str(i) + " is " + str(HV_Value))
+
+    #Sets the HV value on the mpmt test site
+    Set_HV = f'odbedit -c "set /Equipment/PMTS08/Settings/HVset[{i}] {HV_Value}"'
+#    subprocess.run(Set_HV, shell=True, check=True)

--- a/hv_control/start_seq.sh
+++ b/hv_control/start_seq.sh
@@ -1,0 +1,4 @@
+date >> ~/online/log
+
+python3 /home/mpmttest/online/mpmt-mainboard-xilinx/hv_control/set_hv_auto.py "$1"
+                                                  


### PR DESCRIPTION
This includes 3 files. 

1. set_hv_auto.py: This will use the PMT ID to set the high voltage to the Hamamatsu value, it the ID is empty it will skip that PMT. It takes an integer as an argument this will add that value to the Hamamatsu value. Ex: set_hv_auto.py 0 will set the high voltage to the Hamamatsu value but set_hv_auto.py -25 will set the high voltage to 25 les than the Hamamatsu value.
2. set_hv_mpmt.py: This will set the PMT IDs and high voltages of all a given mPMTs.
3. start_seq.sh: This will run set_hv_auto.py, this is to use in the sequencer because the sequencer can't run python code with 2 arguments
